### PR TITLE
Add status to the nodes so we get a circular reference

### DIFF
--- a/src/mtg/initialisation.jl
+++ b/src/mtg/initialisation.jl
@@ -61,7 +61,8 @@ end
         reverse_multiscale_mapping,
         vars_need_init=Dict{String,Any}(),
         type_promotion=nothing;
-        check=true
+        check=true,
+        attribute_name=:plantsimengine_status)
     )
 
 Initialise the status of a plant graph node, taking into account the multiscale mapping, and add it to the statuses dictionary.
@@ -76,6 +77,7 @@ Initialise the status of a plant graph node, taking into account the multiscale 
 - `nodes_with_models`: the nodes that have a model defined for their symbol
 - `type_promotion`: the type promotion to use for the variables
 - `check`: whether to check the mapping for errors (see details)
+- `attribute_name`: the name of the attribute to store the status in the node, by default: `:plantsimengine_status`
 
 # Details
 
@@ -89,7 +91,7 @@ The `check` argument is a boolean indicating if variables initialisation should 
 in the node attributes (using the variable name). If `true`, the function returns an error if the attribute is missing, otherwise it uses the default value from the model.
 
 """
-function init_node_status!(node, statuses, mapped_vars, reverse_multiscale_mapping, vars_need_init=Dict{String,Any}(), type_promotion=nothing; check=true)
+function init_node_status!(node, statuses, mapped_vars, reverse_multiscale_mapping, vars_need_init=Dict{String,Any}(), type_promotion=nothing; check=true, attribute_name=:plantsimengine_status)
     # Check if the node has a model defined for its symbol, if not, no need to compute
     symbol(node) ∉ collect(keys(mapped_vars)) && return
 
@@ -158,6 +160,11 @@ function init_node_status!(node, statuses, mapped_vars, reverse_multiscale_mappi
             end
         end
     end
+
+
+    # Finally, we add the status to the node:
+    node[attribute_name] = st
+
     return st
 end
 

--- a/test/test-mtg-multiscale.jl
+++ b/test/test-mtg-multiscale.jl
@@ -458,9 +458,11 @@ end
     @test length(out.statuses["Leaf"]) == 2
     @test length(out.statuses["Internode"]) == 2
     @test length(out.statuses["Soil"]) == 1
-    @test out.statuses["Soil"][1].node == soil
+    @test out.statuses["Soil"][1].node == get_node(mtg_init, 2)
     @test out.statuses["Soil"][1].soil_water_content !== -Inf
 
+    # Testing that we get the link between the node and its status:
+    @test out.statuses["Soil"][1] == get_node(mtg_init, 2).plantsimengine_status
     # Testing if the value in the status of the leaves is the same as the one in the status of the soil:
     @test out.statuses["Soil"][1].soil_water_content === out.statuses["Leaf"][1].soil_water_content
     @test out.statuses["Soil"][1].soil_water_content === out.statuses["Leaf"][2].soil_water_content
@@ -491,6 +493,10 @@ end
 
     @test out.statuses["Internode"][1].carbon_allocation == 0.5
     @test out.statuses["Leaf"][1].carbon_allocation == 0.5
+
+
+    # Testing that we get the link between the node and its status:
+    @test out.statuses["Leaf"][2] == get_node(mtg_init, 7).plantsimengine_status
 
     # Testing the reference directly:
     ref_values_callocation = getfield(out.statuses["Plant"][1].carbon_allocation, :v)


### PR DESCRIPTION
This PR adds the status to the nodes to create a full circular reference between them and their status. So now, it is possible to get the node from the status and the status from the node. 

This feature is useful when we want to update nodes' values based on other nodes' values.