### PR TITLE
Multiscale hard dependencies

### DIFF
--- a/docs/src/model_coupling/model_coupling_modeler.md
+++ b/docs/src/model_coupling/model_coupling_modeler.md
@@ -60,3 +60,114 @@ PlantSimEngine.dep(::Process2Model) = (process1=Process1Model,)
 ## Soft coupling
 
 A model that takes outputs of another model as inputs is called a soft-coupled model. There is nothing to do on the modeler side to declare a soft-dependency. The detection is done automatically by PlantSimEngine using the inputs and outputs of the models.
+
+## Handling dependencies in a multiscale context
+
+ If a model requires some input variable that is computed at another scale, providing the appropriate mapping will resolve name conflicts and enable proper use of that variable and there will be no extra steps for the user or the modeler.
+
+ In the case of a hard dependency that operates at a different scale from its parent, the same principle applies and there are also no extra steps on the user-side. 
+ 
+ On the other hand, modelers need to bear in mind a couple of subtleties when developing models that possess hard dependencies that operate at a different organ level from their parent : 
+
+ The parent model directly handles the call to its hard dependency model(s), meaning they are not explicitely managed by the dependency graph.
+ Therefore only the owning model of that dependency is visible in the graph, and its hard dependency nodes are internal.
+ 
+ When the caller (or any downstream model that requires some variables from the hard dependency) operates at the same scale, variables are easily accessible, and no mapping is required. 
+
+ If an inner model operates at a different scale/organ level, a modeler must declare hard dependencies with their respective organ level, similarly to the way the user provides a mapping. 
+
+ Conceptually :
+
+```julia
+ PlantSimEngine.dep(m::ParentModel) = (
+    name_provided_in_the_mapping=AbstractHardDependecyModel => ["Organ_Name_1",],
+)
+```
+
+ Here's a concrete example in XPalm, an oil palm model developed on top of PlantSimEngine. 
+ Organs are produced at the phytomer scale, but need to run an age model and a biomass model at the reproductive organs' scales.
+
+```julia
+ PlantSimEngine.dep(m::ReproductiveOrganEmission) = (
+    initiation_age=AbstractInitiation_AgeModel => [m.male_symbol, m.female_symbol],
+    final_potential_biomass=AbstractFinal_Potential_BiomassModel => [m.male_symbol, m.female_symbol],
+)
+```
+
+The user-mapping includes the required models at specific organ levels. Here's the relevant portion of the mapping for the male reproductive organ :
+
+```julia
+mapping = Dict(
+    ...
+    "Male" =>
+    MultiScaleModel(
+        model=XPalm.InitiationAgeFromPlantAge(),
+        mapping=[:plant_age => "Plant",],
+    ),
+    ...
+    XPalm.MaleFinalPotentialBiomass(
+        p.parameters[:male][:male_max_biomass],
+        p.parameters[:male][:age_mature_male],
+        p.parameters[:male][:fraction_biomass_first_male],
+    ),
+    ...
+)
+```
+
+The model's constructor provides convenient default names for the scale corresponding to the reproductive organs. A user may override that if their naming schemes or MTG attributes differ.
+
+```julia
+function ReproductiveOrganEmission(mtg::MultiScaleTreeGraph.Node; phytomer_symbol="Phytomer", male_symbol="Male", female_symbol="Female")
+    ...
+end
+```
+
+But how does a model M calling a hard dependency H provide H's variables when calling H's `run!` function ? The status the user provides M operates at M's organ level, so if used to call H's run! function any required variable for H will be missing.    
+
+PlantSimEngine provides what are called Status Templates in the simulation graph. Each organ level has its own Status template listing the available variables at that scale.
+So when a model M calls a hard dependency H's `run!` function, any required variables can be accessed through the status template of H's organ level.
+
+Using the same example in XPalm : 
+
+```julia
+# Note that the function's 'status' parameter does NOT contain the variables required by the hard dependencies as the calling model's organ level is "Phytomer", not "Male" or "Female"
+
+function PlantSimEngine.run!(m::ReproductiveOrganEmission, models, status, meteo, constants, sim_object)
+    ...
+    status.graph_node_count += 1
+
+    # Create the new organ as a child of the phytomer:
+    st_repro_organ = add_organ!(
+        status.node[1], # The phytomer's internode is its first child 
+        sim_object,  # The simulation object, so we can add the new status 
+        "+", status.sex, 4;
+        index=status.phytomer_count,
+        id=status.graph_node_count,
+        attributes=Dict{Symbol,Any}()
+    )
+
+    # Compute the initiation age of the organ:
+    PlantSimEngine.run!(sim_object.models[status.sex].initiation_age, sim_object.models[status.sex], st_repro_organ, meteo, constants, sim_object)
+    PlantSimEngine.run!(sim_object.models[status.sex].final_potential_biomass, sim_object.models[status.sex], st_repro_organ, meteo, constants, sim_object)
+end
+```
+
+In the above example the organ and its status template are created on the fly.
+When that isn't the case, the status template can be accessed through the simulation graph :
+
+```julia
+function PlantSimEngine.run!(m::ReproductiveOrganEmission, models, status, meteo, constants, sim_object)
+
+    ...
+
+    if status.sex == "Male"
+
+        status_male = sim_object.statuses["Male"][1]
+        run!(sim_object.models["Male"].initiation_age, models, status_male, meteo, constants, sim_object)
+        run!(sim_object.models["Male"].final_potential_biomass, models, status_male, meteo, constants, sim_object)
+    else
+        # Female
+        ...
+    end
+end
+```

--- a/docs/src/model_coupling/model_coupling_modeler.md
+++ b/docs/src/model_coupling/model_coupling_modeler.md
@@ -80,11 +80,11 @@ A model that takes outputs of another model as inputs is called a soft-coupled m
 
 ```julia
  PlantSimEngine.dep(m::ParentModel) = (
-    name_provided_in_the_mapping=AbstractHardDependecyModel => ["Organ_Name_1",],
+    name_provided_in_the_mapping=AbstractHardDependencyModel => ["Organ_Name_1",],
 )
 ```
 
- Here's a concrete example in XPalm, an oil palm model developed on top of PlantSimEngine. 
+ Here's a concrete example in [XPalm](https://github.com/PalmStudio/XPalm.jl), an oil palm model developed on top of PlantSimEngine. 
  Organs are produced at the phytomer scale, but need to run an age model and a biomass model at the reproductive organs' scales.
 
 ```julia

--- a/src/dependencies/dependencies.jl
+++ b/src/dependencies/dependencies.jl
@@ -68,7 +68,7 @@ dep(;models...)
 ```
 """
 function dep(nsteps=1; verbose::Bool=true, vars...)
-    hard_dep = first(hard_dependencies((; vars...), verbose=verbose))
+    hard_dep = hard_dependencies((; vars...), verbose=verbose)
     deps = soft_dependencies(hard_dep, nsteps)
 
     # Return the dependency graph

--- a/src/dependencies/dependencies.jl
+++ b/src/dependencies/dependencies.jl
@@ -68,7 +68,7 @@ dep(;models...)
 ```
 """
 function dep(nsteps=1; verbose::Bool=true, vars...)
-    hard_dep = hard_dependencies((; vars...), verbose=verbose)
+    hard_dep = first(hard_dependencies((; vars...), verbose=verbose))
     deps = soft_dependencies(hard_dep, nsteps)
 
     # Return the dependency graph
@@ -88,12 +88,12 @@ function dep(mapping::Dict{String,T}; verbose::Bool=true) where {T}
     # First step, get the hard-dependency graph and create SoftDependencyNodes for each hard-dependency root. In other word, we want 
     # only the nodes that are not hard-dependency of other nodes. These nodes are taken as roots for the soft-dependency graph because they
     # are independant.
-    soft_dep_graphs_roots = hard_dependencies(mapping; verbose=verbose)
+    soft_dep_graphs_roots, hard_dep_dict = hard_dependencies(mapping; verbose=verbose)
     # Second step, compute the soft-dependency graph between SoftDependencyNodes computed in the first step. To do so, we search the 
     # inputs of each process into the outputs of the other processes, at the same scale, but also between scales. Then we keep only the
     # nodes that have no soft-dependencies, and we set them as root nodes of the soft-dependency graph. The other nodes are set as children
     # of the nodes that they depend on.
-    dep_graph = soft_dependencies_multiscale(soft_dep_graphs_roots, mapping)
+    dep_graph = soft_dependencies_multiscale(soft_dep_graphs_roots, mapping, hard_dep_dict)
     # During the building of the soft-dependency graph, we identified the inputs and outputs of each dependency node, 
     # and also defined **inputs** as MappedVar if they are multiscale, i.e. if they take their values from another scale.
     # What we are missing is that we need to also define **outputs** as multiscale if they are needed by another scale.

--- a/src/dependencies/dependency_graph.jl
+++ b/src/dependencies/dependency_graph.jl
@@ -8,7 +8,7 @@ mutable struct HardDependencyNode{T} <: AbstractDependencyNode
     scale::String
     inputs
     outputs
-    parent::Union{Nothing,HardDependencyNode}
+    parent::Union{Nothing,<:AbstractDependencyNode}
     children::Vector{HardDependencyNode}
 end
 
@@ -39,9 +39,9 @@ A graph of dependencies between models.
 - `roots::T`: the root nodes of the graph.
 - `not_found::Dict{Symbol,DataType}`: the models that were not found in the graph.
 """
-struct DependencyGraph{T}
+struct DependencyGraph{T,N}
     roots::T
-    not_found::Dict{Symbol,DataType}
+    not_found::Dict{Symbol,N}
 end
 
 # Add methods to check if a node is parallelizable:

--- a/src/dependencies/get_model_in_dependency_graph.jl
+++ b/src/dependencies/get_model_in_dependency_graph.jl
@@ -29,3 +29,15 @@ function get_model_nodes(dep_graph::DependencyGraph, model)
 
     return model_node
 end
+
+function get_model_nodes(dep_graph::DependencyGraph, process::Symbol)
+    process_node = Union{SoftDependencyNode,HardDependencyNode}[]
+
+    traverse_dependency_graph!(dep_graph) do node
+        if node.process == process
+            push!(process_node, node)
+        end
+    end
+
+    return process_node
+end

--- a/src/dependencies/hard_dependencies.jl
+++ b/src/dependencies/hard_dependencies.jl
@@ -5,25 +5,29 @@
 Compute the hard dependencies between models.
 """
 function hard_dependencies(models; scale="", verbose::Bool=true)
-    dep_graph = Dict(
-        p => HardDependencyNode(
-            i,
-            p,
-            NamedTuple(),
-            Int[],
-            scale,
-            inputs_(i),
-            outputs_(i),
-            nothing,
-            HardDependencyNode[]
-        ) for (p, i) in pairs(models)
-    )
-    dep_not_found = Dict{Symbol,DataType}()
-    for (process, i) in pairs(models) # for each model in the model list
-        level_1_dep = dep(i) # we get the dependencies of the model
+    dep_graph = initialise_all_as_hard_dependency_node(models, scale)
+    dep_not_found = Dict{Symbol,Any}()
+    for (process, i) in pairs(models) # for each model in the model list. process=:state; i=pairs(models)[process]
+        level_1_dep = dep(i) # we get the required types for the model dependencies
         length(level_1_dep) == 0 && continue # if there is no dependency we skip the iteration
         dep_graph[process].dependency = level_1_dep
-        for (p, depend) in pairs(level_1_dep) # for each dependency of the model i
+        for (p, depend) in pairs(level_1_dep) # for each dependency of the model i. p=:leaf_rank; depend=pairs(level_1_dep)[p]
+            # The dependency can be given as multiscale, e.g. `leaf_area=AbstractLeaf_AreaModel => [m.leaf_symbol],`
+            # This means we should search this model in another scale. This is not done here, but after the call to this 
+            # function in the other method for `hard_dependencies` below.
+            if isa(depend, Pair)
+                if scale != ""
+                    # We skip this hard-dependency if it is multiscale, we compute this afterwards in this case
+                    push!(dep_not_found, p => (parent_process=process, type=first(depend), scales=last(depend)))
+                    continue
+                else
+                    # If we are not in a multi-scale setup e.g. in a ModelList, we shouldn't use a multiscale model.
+                    # But we still authorize it with a warning, and then proceed searching the dependency in this model list.
+                    verbose && @warn "Model $i has a multiscale hard dependency on $(first(depend)): $depend. Trying to find the model in this scale instead."
+                    depend = first(depend)
+                end
+            end
+
             if hasproperty(models, p)
                 if typeof(getfield(models, p)) <: depend
                     parent_dep = dep_graph[process]
@@ -82,19 +86,102 @@ function hard_dependencies(models; scale="", verbose::Bool=true)
     return DependencyGraph(unique_roots, dep_not_found)
 end
 
+"""
+    initialise_all_as_hard_dependency_node(models)
+
+Take a set of models and initialise them all as a hard dependency node, and 
+return a dictionary of `:process => HardDependencyNode`.
+"""
+function initialise_all_as_hard_dependency_node(models, scale)
+    dep_graph = Dict(
+        p => HardDependencyNode(
+            i,
+            p,
+            NamedTuple(),
+            Int[],
+            scale,
+            inputs_(i),
+            outputs_(i),
+            nothing,
+            HardDependencyNode[]
+        ) for (p, i) in pairs(models)
+    )
+
+    return dep_graph
+end
+
+
 # When we use a mapping (multiscale), we return the set of soft-dependencies (we put the hard-dependencies as their children):
 function hard_dependencies(mapping::Dict{String,T}; verbose::Bool=true) where {T}
     full_vars_mapping = Dict(first(mod) => Dict(get_mapping(last(mod))) for mod in mapping)
-
     soft_dep_graphs = Dict{String,Any}()
     not_found = Dict{Symbol,DataType}()
+
+    mods = Dict(organ => parse_models(get_models(model)) for (organ, model) in mapping)
+
+    # For each scale, move the hard-dependency models as children of the its parent model.
+    # Note: this is mono-scale at this point (computes each scale independently)
+    hard_deps = Dict(organ => hard_dependencies(mods_scale, scale=organ, verbose=false) for (organ, mods_scale) in mods)
+
+    # If some models needed as hard-dependency are not found in their own scale, check the other scales:
     for (organ, model) in mapping
-        # organ = "Leaf"; model = mapping[organ]
-        mods = parse_models(get_models(model))
+        # organ = "Plant"; model = mapping[organ]
+        # filtering the hard dependency that were defined as multiscale (NamedTuple with information)
+        multiscale_hard_dep = filter(x -> isa(last(x), NamedTuple), hard_deps[organ].not_found)
+        for (p, (parent_process, model_type, scales)) in multiscale_hard_dep
+            # debug: p = :initiation_age; parent_process, model_type, scales = multiscale_hard_dep[p]
+            parent_node = get_model_nodes(hard_deps[organ], parent_process)
+            if length(parent_node) == 0
+                continue
+            end
+            parent_node = only(parent_node)
+            # The parent node is the one that needs the hard dependency we are searching
+            is_found = Ref(false) # Flag to check if the model was found in the other scales
+            for s in scales # s="Phytomer"
+                dep_node_model = filter(x -> x.scale == s, get_model_nodes(hard_deps[s], p))
+                # Note: here we apply a filter because we modify the graph dynamically, and sometimes
+                # we have already computed multiscale hard-dependencies, which can show up here,
+                # so we only keep the models that were declared at the scale we are looking.
 
-        # Move some models below others when they are manually linked (hard-dependency):
-        hard_deps = hard_dependencies((; mods...), scale=organ, verbose=verbose)
+                if length(dep_node_model) > 0
+                    is_found[] = true
+                else
+                    error("Model `$(typeof(parent_node.value))` from scale $organ requires a model of type `$model_type` at scale $s as a hard dependency, but no model was found for this process.")
+                end
+                dep_node_model = only(dep_node_model)
 
+                if !isa(dep_node_model.value, model_type)
+                    error("Model `$(typeof(parent_node.value))` from scale $organ requires a model of type `$model_type` at scale $s as a hard dependency, but the model found for this process is of type $(typeof(dep_node_model.value)).")
+                end
+
+                # We make a new node out of the previous one:
+                new_node = HardDependencyNode(
+                    dep_node_model.value,
+                    dep_node_model.process,
+                    dep_node_model.dependency,
+                    dep_node_model.missing_dependency,
+                    dep_node_model.scale,
+                    dep_node_model.inputs,
+                    dep_node_model.outputs,
+                    parent_node,
+                    dep_node_model.children
+                )
+                # Note that we make a new node just in case it is a hard-dependency of a model at its own scale
+                # and at a different scale (several models can take control over a model)
+
+                # Add our new node as a child of the parent node (the one that requires it as a hard dependency)
+                push!(parent_node.children, new_node)
+                # If it was a root node, we delete it as a root node.
+                if dep_node_model in values(hard_deps[s].roots)
+                    delete!(hard_deps[s].roots, p) # We delete the value that has the process as key
+                end
+            end
+            # If the model was found in at least one another scale, delete it from the not_found Dict
+            is_found[] && delete!(hard_deps[organ].not_found, p)
+        end
+    end
+
+    for (organ, model) in mapping
         # Get the status given by the user, that is used to set the default values of the variables in the mapping:
         st = get_status(model)
         if isnothing(st)
@@ -104,7 +191,7 @@ function hard_dependencies(mapping::Dict{String,T}; verbose::Bool=true) where {T
         end
 
         d_vars = Dict{Symbol,Vector{Pair{Symbol,NamedTuple}}}()
-        for (procname, node) in hard_deps.roots # procname = :leaf_surface ; node = hard_deps.roots[procname]
+        for (procname, node) in hard_deps[organ].roots # procname = :leaf_surface ; node = hard_deps.roots[procname]
             var = Pair{Symbol,NamedTuple}[]
             traverse_dependency_graph!(node, x -> variables_multiscale(x, organ, full_vars_mapping, st), var)
             push!(d_vars, procname => var)
@@ -126,11 +213,19 @@ function hard_dependencies(mapping::Dict{String,T}; verbose::Bool=true) where {T
                 SoftDependencyNode[],
                 [0] # Vector of zeros of length = number of time-steps
             )
-            for (process_, soft_dep_vars) in hard_deps.roots # proc_ = :carbon_assimilation ; soft_dep_vars = hard_deps.roots[proc_]
+            for (process_, soft_dep_vars) in hard_deps[organ].roots # proc_ = :carbon_assimilation ; soft_dep_vars = hard_deps.roots[proc_]
         )
 
+        # Update the parent node of the hard dependency nodes to be the new SoftDependencyNode instead of the old
+        # HardDependencyNode.
+        for (p, node) in soft_dep_graph
+            for n in node.hard_dependency
+                n.parent = node
+            end
+        end
+
         soft_dep_graphs[organ] = (soft_dep_graph=soft_dep_graph, inputs=inputs_process, outputs=outputs_process)
-        not_found = merge(not_found, hard_deps.not_found)
+        not_found = merge(not_found, hard_deps[organ].not_found)
     end
 
     return DependencyGraph(soft_dep_graphs, not_found)

--- a/src/dependencies/hard_dependencies.jl
+++ b/src/dependencies/hard_dependencies.jl
@@ -204,6 +204,16 @@ function hard_dependencies(mapping::Dict{String,T}; verbose::Bool=true) where {T
                 # Add our new node as a child of the parent node (the one that requires it as a hard dependency)
                 push!(parent_node.children, new_node)
 
+                # previously created nested hard dependency nodes' ancestors that have the new_node model as their caller now point to an outdated parent 
+                # (and hard dependency node in an outdated state), so their grandparent when traversing upwards might incorrectly be set to nothing
+                # update their parent to the correct new node
+                for (hd_sym, hd_node) in hard_dependency_dict
+
+                    if hd_node.parent.process == p
+                        hd_node.parent = new_node
+                    end
+                end
+
                 # add the new node to the flat list of hard deps, as they aren't trivial to access in the dep graph, and we might need them later for a couple of things
                 hard_dependency_dict[p] = new_node
 

--- a/src/dependencies/soft_dependencies.jl
+++ b/src/dependencies/soft_dependencies.jl
@@ -138,7 +138,7 @@ function soft_dependencies(d::DependencyGraph{Dict{Symbol,HardDependencyNode}}, 
 end
 
 # For multiscale mapping:
-function soft_dependencies_multiscale(soft_dep_graphs_roots::DependencyGraph{Dict{String,Any}}, mapping::Dict{String,A}, hard_dep_dict::Dict{Symbol, HardDependencyNode}) where {A<:Any}
+function soft_dependencies_multiscale(soft_dep_graphs_roots::DependencyGraph{Dict{String,Any}}, mapping::Dict{String,A}, hard_dep_dict::Dict{Pair{Symbol, String}, HardDependencyNode}) where {A<:Any}
     mapped_vars = mapped_variables(mapping, soft_dep_graphs_roots, verbose=false)
     rev_mapping = reverse_mapping(mapped_vars, all=false)
 
@@ -178,7 +178,7 @@ function soft_dependencies_multiscale(soft_dep_graphs_roots::DependencyGraph{Dic
                             roots_at_given_scale = soft_dep_graphs_roots.roots[i.scale][:soft_dep_graph]
                             if !(parent_soft_dep in keys(roots_at_given_scale))                                                               
                                 master_node = ()
-                                for (hd_key, hd) in hard_dep_dict 
+                                for ((hd_key, hd_scale), hd) in hard_dep_dict 
                                     if parent_soft_dep == hd_key     
                                         master_node = hd                                                                                                                                                                                       
                                         depth = 0
@@ -257,7 +257,7 @@ function soft_dependencies_multiscale(soft_dep_graphs_roots::DependencyGraph{Dic
                             roots_at_given_scale = soft_dep_graphs_roots.roots[org][:soft_dep_graph]   
                             if !(parent_soft_dep in keys(roots_at_given_scale))                                                               
                                 master_node = ()
-                                for (hd_key, hd) in hard_dep_dict 
+                                for ((hd_key, hd_scale), hd) in hard_dep_dict 
                                     if parent_soft_dep == hd_key     
                                         master_node = hd                                                                                                                                                                                       
                                         depth = 0

--- a/src/dependencies/soft_dependencies.jl
+++ b/src/dependencies/soft_dependencies.jl
@@ -412,6 +412,7 @@ end
 - `inputs::Dict{Symbol, Vector{Pair{Symbol}, Tuple{Symbol, Vararg{Symbol}}}}`: a dict of process => [:subprocess => (:var1, :var2)].
 - `soft_dep_graphs::Dict{String, ...}`: a dict of organ => (soft_dep_graph, inputs, outputs).
 - `rev_mapping::Dict{Symbol, Symbol}`: a dict of mapped variable => source variable (this is the reverse mapping).
+- 'hard_dependencies_from_other_scale' : a vector of HardDependencyNode to provide access to the hard dependencies without traversing the whole graph
 
 # Details
 

--- a/src/mtg/initialisation.jl
+++ b/src/mtg/initialisation.jl
@@ -21,7 +21,7 @@ a dictionary of variables that need to be initialised or computed by other model
 
 `(;statuses, status_templates, reverse_multiscale_mapping, vars_need_init, nodes_with_models)`
 """
-function init_statuses(mtg, mapping, dependency_graph=hard_dependencies(mapping; verbose=false); type_promotion=nothing, verbose=false, check=true)
+function init_statuses(mtg, mapping, dependency_graph=first(hard_dependencies(mapping; verbose=false)); type_promotion=nothing, verbose=false, check=true)
     # We compute the variables mapping for each scale:
     mapped_vars = mapped_variables(mapping, dependency_graph, verbose=verbose)
 
@@ -308,7 +308,7 @@ function init_simulation(mtg, mapping; nsteps=1, outputs=nothing, type_promotion
 
     # Get the status of each node by node type, pre-initialised considering multi-scale variables:
     statuses, status_templates, reverse_multiscale_mapping, vars_need_init =
-        init_statuses(mtg, mapping, hard_dependencies(mapping; verbose=false); type_promotion=type_promotion, verbose=verbose, check=check)
+        init_statuses(mtg, mapping, first(hard_dependencies(mapping; verbose=false)); type_promotion=type_promotion, verbose=verbose, check=check)
 
     # Print an info if models are declared for nodes that don't exist in the MTG:
     if check && any(x -> length(last(x)) == 0, statuses)

--- a/src/mtg/mapping/compute_mapping.jl
+++ b/src/mtg/mapping/compute_mapping.jl
@@ -1,5 +1,5 @@
 """
-    mapped_variables(mapping, dependency_graph=hard_dependencies(mapping; verbose=false); verbose=false)
+    mapped_variables(mapping, dependency_graph=first(hard_dependencies(mapping; verbose=false)); verbose=false)
 
 Get the variables for each organ type from a dependency graph, with `MappedVar`s for the multiscale mapping.
 
@@ -11,7 +11,7 @@ However, models that are identified as hard-dependencies are not given individua
 nodes under other models.
 - `verbose::Bool`: whether to print the stacktrace of the search for the default value in the mapping.
 """
-function mapped_variables(mapping, dependency_graph=hard_dependencies(mapping; verbose=false); verbose=false)
+function mapped_variables(mapping, dependency_graph=first(hard_dependencies(mapping; verbose=false)); verbose=false)
     # Initialise a dict that defines the multiscale variables for each organ type:
     mapped_vars = mapped_variables_no_outputs_from_other_scale(mapping, dependency_graph)
 
@@ -36,7 +36,7 @@ function mapped_variables(mapping, dependency_graph=hard_dependencies(mapping; v
 end
 
 """
-    mapped_variables_no_outputs_from_other_scale(mapping, dependency_graph=hard_dependencies(mapping; verbose=false))
+    mapped_variables_no_outputs_from_other_scale(mapping, dependency_graph=first(hard_dependencies(mapping; verbose=false)))
 
 Get the variables for each organ type from a dependency graph, without the variables that are outputs from another scale.
 
@@ -54,7 +54,7 @@ This function returns a dictionary with the (multiscale-) inputs and outputs var
 Note that this function does not include the variables that are outputs from another scale and not computed by this scale,
 see `mapped_variables_with_outputs_as_inputs` for that.
  """
-function mapped_variables_no_outputs_from_other_scale(mapping, dependency_graph=hard_dependencies(mapping; verbose=false))
+function mapped_variables_no_outputs_from_other_scale(mapping, dependency_graph=first(hard_dependencies(mapping; verbose=false)))
     nodes_insouts = Dict(organ => (inputs=ins, outputs=outs) for (organ, (soft_dep_graph, ins, outs)) in dependency_graph.roots)
     ins = Dict{String,NamedTuple}(organ => flatten_vars(vcat(values(ins)...)) for (organ, (ins, outs)) in nodes_insouts)
     outs = Dict{String,NamedTuple}(organ => flatten_vars(vcat(values(outs)...)) for (organ, (ins, outs)) in nodes_insouts)

--- a/src/mtg/mapping/reverse_mapping.jl
+++ b/src/mtg/mapping/reverse_mapping.jl
@@ -69,7 +69,7 @@ Dict{String, Dict{String, Dict{Symbol, Any}}} with 3 entries:
 """
 function reverse_mapping(mapping::Dict{String,T}; all=true) where {T<:Any}
     # Method for the reverse mapping applied directly on the mapping (not used in the code base)
-    mapped_vars = mapped_variables(mapping, hard_dependencies(mapping; verbose=false), verbose=false)
+    mapped_vars = mapped_variables(mapping, first(hard_dependencies(mapping; verbose=false)), verbose=false)
     reverse_mapping(mapped_vars, all=all)
 end
 

--- a/src/processes/model_initialisation.jl
+++ b/src/processes/model_initialisation.jl
@@ -151,7 +151,7 @@ function to_initialize(mapping::Dict{String,T}, graph=nothing) where {T}
     end
 
     to_init = Dict(org => Symbol[] for org in keys(mapping))
-    mapped_vars = mapped_variables(mapping, hard_dependencies(mapping; verbose=false), verbose=false)
+    mapped_vars = mapped_variables(mapping, first(hard_dependencies(mapping; verbose=false)), verbose=false)
     for (org, vars) in mapped_vars
         for (var, val) in vars
             if isa(val, UninitializedVar) && var ∉ vars_in_mtg

--- a/test/test-mtg-multiscale-cyclic-dep.jl
+++ b/test/test-mtg-multiscale-cyclic-dep.jl
@@ -47,8 +47,8 @@ out_vars = Dict(
 
     @test_throws "Cyclic dependency detected in the graph. Cycle:" dep(mapping_cyclic)
 
-    soft_dep_graphs_roots = PlantSimEngine.hard_dependencies(mapping_cyclic)
-    dep_graph = PlantSimEngine.soft_dependencies_multiscale(soft_dep_graphs_roots, mapping_cyclic)
+    soft_dep_graphs_roots, hard_dep_dict = PlantSimEngine.hard_dependencies(mapping_cyclic)
+    dep_graph = PlantSimEngine.soft_dependencies_multiscale(soft_dep_graphs_roots, mapping_cyclic, hard_dep_dict)
     iscyclic, cycle_vec = PlantSimEngine.is_graph_cyclic(dep_graph; warn=false)
 
     @test iscyclic
@@ -95,9 +95,9 @@ end
 
     @test_nowarn dep(mapping_nocyclic)
 
-    soft_dep_graphs_roots = PlantSimEngine.hard_dependencies(mapping_nocyclic)
+    soft_dep_graphs_roots, hard_dep_dict = PlantSimEngine.hard_dependencies(mapping_nocyclic)
     # soft_dep_graphs_roots.roots["Leaf"].inputs
-    dep_graph = PlantSimEngine.soft_dependencies_multiscale(soft_dep_graphs_roots, mapping_nocyclic)
+    dep_graph = PlantSimEngine.soft_dependencies_multiscale(soft_dep_graphs_roots, mapping_nocyclic, hard_dep_dict)
     iscyclic, cycle_vec = PlantSimEngine.is_graph_cyclic(dep_graph; warn=false)
 
     @test !iscyclic

--- a/test/test-mtg-multiscale.jl
+++ b/test/test-mtg-multiscale.jl
@@ -168,7 +168,7 @@ end
     type_promotion = nothing
     nsteps = 2
     dependency_graph = dep(mapping_1)
-    organs_statuses, others = PlantSimEngine.init_statuses(mtg_init, mapping_1, PlantSimEngine.hard_dependencies(mapping_1; verbose=false); type_promotion=type_promotion)
+    organs_statuses, others = PlantSimEngine.init_statuses(mtg_init, mapping_1, first(PlantSimEngine.hard_dependencies(mapping_1; verbose=false)); type_promotion=type_promotion)
 
     @test collect(keys(organs_statuses)) == ["Soil", "Internode", "Plant", "Leaf"]
     @test collect(keys(organs_statuses["Soil"][1])) == [:node, :soil_water_content]


### PR DESCRIPTION
Models that are hard dependency of another scale from which they were defined are not taken into account yet.

What we need to do is:

1. Put these models as hard-dependency children of the model at the other scale
2. Update the inputs/outputs of the parent model using the hard-dependency model

Step 1 is done already, but there is much difficulty with step 2.
The inputs and outputs variables are used for two distinct purposes: 
- to compute the template status for each scale
- to compute the soft-dependency graph, which only uses inputs and outputs of models to know when each model should be run. The new difficulty is that now we should also check for models that are in other scales, checking if they have any variable that is computed by a hard-dependency model at the same scale that is currently computed.

If we update the variables of the parent model, they will be used to compute the soft dependencies at the scale of the parent model. This is not desired because the variable is not computed at this scale but at the other scale, so it is not present in the parent scale status.

We need to be more explicit on the way we manage variables and scales. We should probably use wrappers around variables in the dependency nodes already, to be sure where a variable is computed. Caution: the variables from the multiscale hard-dependency models are not multiscale variables! The models are just run from another scale, but the status is the one at the scale of the hard-dependency model.

