### PR TITLE
Downstream testing CI changes

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -33,7 +33,7 @@ jobs:
           - x64
         package:
         - {user: PalmStudio, repo: XPalm.jl, branch: main, default: main}
-        - {user: VEZY, repo: PlantBioPhysics.jl, branch: CI_downstream_changes_tests, default: master}
+        - {user: VEZY, repo: PlantBioPhysics.jl, branch: master, default: master}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
- Dev branch removal
- Fail action unless the tests check against dependencies main/master (enables testing with a downstream package PR, and ensures dependencies are in a 'releasable' state before tests pass).