### PR TITLE
Filter out empty status vectors

### DIFF
--- a/src/mtg/GraphSimulation.jl
+++ b/src/mtg/GraphSimulation.jl
@@ -106,6 +106,9 @@ function convert_outputs(outs::Dict{String,O} where O, sink; refvectors=false, n
                     refv = (refv..., var)
                 end
             end
+        else
+            @warn "No instance found at the $organ scale, no output available, removing it from the Dict"
+            continue
         end
        
         # Get the new NamedTuple type


### PR DESCRIPTION
Type deduction on outputs requires inspecting the first element of status vectors. Avoid doing so in cases where no organ was created and that vector is empty.