### PR TITLE
Restore incremental lifecycle performance with distributed outputs

### DIFF
--- a/src/composite_model/compilation.jl
+++ b/src/composite_model/compilation.jl
@@ -1811,6 +1811,8 @@ function _append_added_many_sources!(
     binding::CompiledModelInputBinding,
     added_ids,
     applications_by_object,
+    applications_by_id,
+    distributed_outputs,
 )
     binding.multiplicity == :many || return false
     default_scope = _default_dependency_scope(model, binding.consumer_id)
@@ -1852,7 +1854,9 @@ function _append_added_many_sources!(
             new_source_ids,
             binding.source_var,
             binding.process,
-            binding.application;
+            binding.application,
+            distributed_outputs;
+            applications_by_id=applications_by_id,
             allow_empty=binding.selector isa OptionalOne,
         )
     end
@@ -2060,6 +2064,7 @@ function _extend_model_status_views(
     rewired_consumer_ids,
     affected_temporal_keys,
     previous_temporal_sources,
+    distributed_outputs,
     previous_views=compiled.status_views_by_target,
 )
     views = compiled.status_views_by_target
@@ -2100,6 +2105,7 @@ function _extend_model_status_views(
             get(input_bindings_by_target, key, ()),
             applications_by_id,
             positions,
+            distributed_outputs,
         )
         views[key] = isnothing(previous_view) ?
                      current_view :
@@ -2376,6 +2382,24 @@ function _extend_compiled_scene(
             push!(get!(applications_by_object, object_id, Any[]), application)
         end
     end
+    manual_application_ids = compiled.scenario_plan.manual_application_ids
+    distributed_outputs, changed_distributed_output_target_ids =
+        _refresh_model_distributed_outputs(
+            model,
+            compiled.distributed_outputs,
+            applications,
+            applications_by_id,
+            manual_application_ids,
+            compiled.scenario_plan.distributed_output_plans,
+            added_ids,
+            new_targets,
+            pure_addition,
+        )
+    union!(changed_target_ids_seed, changed_distributed_output_target_ids)
+    union!(
+        changed_application_ids_seed,
+        (first(key) for key in changed_distributed_output_target_ids),
+    )
     _runtime_performance_finish!(
         performance,
         :application_target_refresh,
@@ -2548,7 +2572,6 @@ function _extend_compiled_scene(
     )
 
     started_at = _runtime_performance_start(performance)
-    manual_application_ids = compiled.scenario_plan.manual_application_ids
     added_input_binding_capacity = sum(
         length(_model_input_names(application)) *
         length(application.target_ids)
@@ -2650,6 +2673,8 @@ function _extend_compiled_scene(
                 binding,
                 added_ids,
                 applications_by_object,
+                applications_by_id,
+                distributed_outputs,
             )
         end
         if appended_sources
@@ -2675,6 +2700,8 @@ function _extend_compiled_scene(
             binding.plan,
             applications_by_object,
             applications_by_id,
+            nothing,
+            distributed_outputs,
         )
         old_cache_key = _many_binding_share_key(model, binding)
         if !isnothing(old_cache_key) &&
@@ -2719,6 +2746,7 @@ function _extend_compiled_scene(
                 manual_application_ids,
                 applications_by_object,
                 applications_by_id,
+                distributed_outputs,
             )
             last_new_binding = length(input_bindings)
             if first_new_binding <= last_new_binding
@@ -2828,6 +2856,7 @@ function _extend_compiled_scene(
         rewired_consumer_ids,
         affected_temporal_keys,
         previous_temporal_sources,
+        distributed_outputs,
         previous_views,
     )
     _runtime_performance_finish!(
@@ -2877,7 +2906,7 @@ function _extend_compiled_scene(
         dynamic_input_binding_indices,
         dynamic_call_binding_indices,
         many_binding_cache,
-        compiled.distributed_outputs,
+        distributed_outputs,
         call_owners,
         application_children,
         status_views_by_target,
@@ -4364,6 +4393,243 @@ function _compile_model_distributed_outputs(
         ownership,
         _index_model_output_destination_ids(bindings),
     )
+end
+
+_distributed_output_binding_key(binding) = (
+    binding.application_id,
+    binding.execution_object_id,
+    binding.group,
+)
+
+function _changed_distributed_output_target_ids(previous, current)
+    previous_membership = Dict(
+        _distributed_output_binding_key(binding) => binding.destination_ids
+        for binding in previous.bindings
+    )
+    current_membership = Dict(
+        _distributed_output_binding_key(binding) => binding.destination_ids
+        for binding in current.bindings
+    )
+    changed = Set{Tuple{Symbol,ObjectId}}()
+    for key in union(keys(previous_membership), keys(current_membership))
+        get(previous_membership, key, nothing) ==
+        get(current_membership, key, nothing) && continue
+        push!(changed, (key[1], key[2]))
+    end
+    return changed
+end
+
+function _refresh_model_distributed_outputs(
+    model::CompositeModel,
+    previous::NoCompiledDistributedOutputs,
+    applications,
+    applications_by_id,
+    manual_application_ids,
+    plans,
+    added_ids,
+    new_targets,
+    pure_addition,
+)
+    return previous, Set{Tuple{Symbol,ObjectId}}()
+end
+
+function _stage_distributed_writer_owner!(
+    staged,
+    previous,
+    object_id::ObjectId,
+    variable::Symbol,
+    owner::CompiledWriterOwner,
+)
+    key = (object_id, variable)
+    owners = get!(staged, key) do
+        copy(get(previous.writer_ownership, key, CompiledWriterOwner[]))
+    end
+    push!(owners, owner)
+    return staged
+end
+
+function _incremental_distributed_output_addition!(
+    model::CompositeModel,
+    previous::CompiledDistributedOutputs,
+    applications,
+    applications_by_id,
+    manual_application_ids,
+    plans::CompiledDistributedOutputPlans,
+    added_ids,
+    new_targets,
+)
+    for (application_id, object_ids) in new_targets
+        isempty(object_ids) && continue
+        application = applications_by_id[application_id]
+        isempty(_application_plans(plans.by_application, application.slot)) ||
+            return nothing
+    end
+
+    resolved_additions = ResolvedModelOutputDestination[]
+    for binding in previous.bindings
+        default_scope = _default_dependency_scope(
+            model,
+            binding.execution_object_id,
+        )
+        destination_ids = ObjectId[
+            object_id for object_id in added_ids
+            if _selector_matches_object_id(
+                model,
+                binding.matcher,
+                object_id;
+                context=binding.execution_object_id,
+                default_to_context=true,
+                default_scope=default_scope,
+            ) && !(object_id in binding.destination_ids)
+        ]
+        isempty(destination_ids) && continue
+        _sort_object_ids!(destination_ids)
+        if !isempty(binding.destination_ids) &&
+           !_object_id_isless(last(binding.destination_ids), first(destination_ids))
+            return nothing
+        end
+        push!(
+            resolved_additions,
+            ResolvedModelOutputDestination(
+                binding.plan,
+                binding.execution_object_id,
+                destination_ids,
+            ),
+        )
+    end
+
+    _validate_model_output_destination_statuses!(model, resolved_additions)
+    _validate_required_model_output_destinations!(model, resolved_additions)
+    staged_ownership = Dict{
+        Tuple{ObjectId,Symbol},
+        Vector{CompiledWriterOwner},
+    }()
+    for (application_id, object_ids) in new_targets
+        application = applications_by_id[application_id]
+        application.id in manual_application_ids && continue
+        for object_id in object_ids
+            for variable in _model_canonical_output_names(application)
+                _stage_distributed_writer_owner!(
+                    staged_ownership,
+                    previous,
+                    object_id,
+                    variable,
+                    CompiledWriterOwner(
+                        application.plan.slot,
+                        application.id,
+                        object_id,
+                        nothing,
+                        :application_target,
+                    ),
+                )
+            end
+        end
+    end
+    for resolved in resolved_additions
+        plan = resolved.plan
+        for destination_id in resolved.destination_ids
+            for variable_ in keys(plan.declarations)
+                variable = Symbol(variable_)
+                _stage_distributed_writer_owner!(
+                    staged_ownership,
+                    previous,
+                    destination_id,
+                    variable,
+                    CompiledWriterOwner(
+                        plan.application_slot,
+                        plan.application_id,
+                        resolved.execution_object_id,
+                        plan.group,
+                        :output_destination,
+                    ),
+                )
+            end
+        end
+    end
+    _validate_compiled_writer_ownership!(staged_ownership, applications)
+    _prepare_model_output_destination_statuses!(model, resolved_additions)
+
+    column_additions = Any[]
+    for resolved in resolved_additions
+        key = (resolved.plan.application_id, resolved.execution_object_id)
+        groups = previous.by_execution_target[key]
+        binding = getproperty(groups, resolved.plan.group)
+        columns = _model_output_destination_columns(model, resolved)
+        for variable in keys(binding.declarations)
+            existing_references = parent(getproperty(binding.columns, variable))
+            added_references = parent(getproperty(columns, variable))
+            eltype(added_references) <: eltype(existing_references) ||
+                return nothing
+        end
+        push!(column_additions, (binding=binding, resolved=resolved, columns=columns))
+    end
+
+    for (key, owners) in staged_ownership
+        previous.writer_ownership[key] = owners
+    end
+    for addition in column_additions
+        binding = addition.binding
+        resolved = addition.resolved
+        for variable_ in keys(binding.declarations)
+            variable = Symbol(variable_)
+            append!(
+                parent(getproperty(binding.columns, variable)),
+                parent(getproperty(addition.columns, variable)),
+            )
+            indexed_ids = previous.destination_ids_by_application_variable[
+                (binding.application_id, variable)
+            ]
+            indexed_ids === binding.destination_ids ||
+                _insert_sorted_object_ids!(indexed_ids, resolved.destination_ids)
+        end
+        first_position = length(binding.destination_ids) + 1
+        append!(binding.destination_ids, resolved.destination_ids)
+        for (offset, object_id) in enumerate(resolved.destination_ids)
+            binding.destination_index[object_id] = first_position + offset - 1
+        end
+        binding.membership_generation = UInt64(model.revision)
+    end
+    changed_targets = Set{Tuple{Symbol,ObjectId}}(
+        (
+            resolved.plan.application_id,
+            resolved.execution_object_id,
+        )
+        for resolved in resolved_additions
+    )
+    return previous, changed_targets
+end
+
+function _refresh_model_distributed_outputs(
+    model::CompositeModel,
+    previous::CompiledDistributedOutputs,
+    applications,
+    applications_by_id,
+    manual_application_ids,
+    plans::CompiledDistributedOutputPlans,
+    added_ids,
+    new_targets,
+    pure_addition,
+)
+    if pure_addition
+        incremental = _incremental_distributed_output_addition!(
+            model,
+            previous,
+            applications,
+            applications_by_id,
+            manual_application_ids,
+            plans,
+            added_ids,
+            new_targets,
+        )
+        isnothing(incremental) || return incremental
+    end
+    current = _compile_model_distributed_outputs(
+        model,
+        applications,
+        manual_application_ids,
+        plans,
+    )
+    return current, _changed_distributed_output_target_ids(previous, current)
 end
 
 function _prepare_model_input_defaults!(model::CompositeModel, applications)

--- a/src/composite_model/registry_topology.jl
+++ b/src/composite_model/registry_topology.jl
@@ -1714,9 +1714,7 @@ function refresh_bindings!(
         dirty_object_ids = delta.structural_dirty_ids
         can_extend = !force &&
                      !isnothing(model.binding_cache) &&
-                     !isempty(dirty_object_ids) &&
-                     model.binding_cache.distributed_outputs isa
-                     NoCompiledDistributedOutputs
+                     !isempty(dirty_object_ids)
         if can_extend && delta.structural_kind == :addition
             model.binding_cache = _extend_compiled_scene(
                 model,

--- a/src/composite_model/runtime_outputs.jl
+++ b/src/composite_model/runtime_outputs.jl
@@ -3489,6 +3489,91 @@ function _model_execution_batch_accepts_target(
     return isequal(provider, batch.environment_provider)
 end
 
+function _extend_execution_target_call_batches!(
+    target::CompiledExecutionTarget,
+    compiled::CompiledCompositeModel,
+    env_bindings::CompiledEnvironmentBindings,
+    temporal_streams,
+    output_retention,
+    constants,
+)
+    context = target.context
+    context isa RunContext || return false
+    current_call_bindings = get(
+        compiled.call_bindings_by_target,
+        (context.application.id, target.object_id),
+        (),
+    )
+    length(context.calls) == length(current_call_bindings) || return false
+    staged = Tuple{Any,Any}[]
+    staged_bindings = Tuple{Any,Any}[]
+    for (call_targets, binding) in zip(context.calls, current_call_bindings)
+        _compiled_call_name(call_targets.binding) ==
+        _compiled_call_name(binding) || return false
+        push!(staged_bindings, (call_targets, binding))
+        _compiled_call_mode(binding) === :initializer && continue
+        current_application_ids = Set(binding.callee_application_ids)
+        all(
+            batch -> batch.application.id in current_application_ids,
+            call_targets.execution_batches,
+        ) || return false
+        for application_id in binding.callee_application_ids
+            application = _compiled_application_by_id(compiled, application_id)
+            batches = AbstractExecutionBatch[
+                batch for batch in call_targets.execution_batches
+                if batch.application.id == application_id
+            ]
+            isempty(batches) && return false
+            existing_ids = Set(
+                execution_target.object_id
+                for batch in batches
+                for execution_target in batch.targets
+            )
+            current_ids = ObjectId[
+                object_id for object_id in binding.callee_object_ids
+                if _call_binding_target_matches(binding, application, object_id)
+            ]
+            all(object_id -> object_id in current_ids, existing_ids) ||
+                return false
+            added_ids = ObjectId[
+                object_id for object_id in current_ids
+                if !(object_id in existing_ids)
+            ]
+            isempty(added_ids) && continue
+            _sort_object_ids!(added_ids)
+            destination_batch = last(batches)
+            for object_id in added_ids
+                execution_target = _compiled_model_execution_target(
+                    compiled,
+                    env_bindings,
+                    application,
+                    object_id,
+                    temporal_streams,
+                    output_retention,
+                    constants,
+                )
+                _model_execution_batch_accepts_target(
+                    destination_batch,
+                    execution_target,
+                    env_bindings,
+                    application,
+                ) || return false
+                push!(staged, (destination_batch.targets, execution_target))
+            end
+        end
+    end
+    for (targets, execution_target) in staged
+        push!(targets, execution_target)
+    end
+    for (call_targets, binding) in staged_bindings
+        call_targets.binding = binding
+    end
+    target.call_bindings = current_call_bindings
+    target.call_bindings_signature =
+        _call_bindings_signature(current_call_bindings)
+    return true
+end
+
 function _refresh_model_execution_group_delta!(
     previous_group::CompiledApplicationExecutionGroup,
     compiled::CompiledCompositeModel,
@@ -3535,16 +3620,33 @@ function _refresh_model_execution_group_delta!(
             batch_index, target_index = location
             previous_group.batches[batch_index].targets[target_index]
         end
-        change_reason = isnothing(previous_target) ?
-                        :new_target :
-                        _model_execution_target_change_reason(
+        change_reason = if isnothing(previous_target)
+            :new_target
+        else
+            _model_execution_target_change_reason(
+                previous_target,
+                compiled,
+                env_bindings,
+                application,
+                output_retention,
+            )
+        end
+        isnothing(change_reason) && continue
+        if change_reason === :call_bindings &&
+           _extend_execution_target_call_batches!(
             previous_target,
             compiled,
             env_bindings,
-            application,
+            temporal_streams,
             output_retention,
+            constants,
         )
-        isnothing(change_reason) && continue
+            _runtime_performance_count!(
+                performance,
+                :execution_target_call_batches_extended,
+            )
+            continue
+        end
         target = _compiled_model_execution_target(
             compiled,
             env_bindings,

--- a/src/composite_model/status_conversion.jl
+++ b/src/composite_model/status_conversion.jl
@@ -266,6 +266,10 @@ function _materialize_status_value(
     reuse::Bool=false,
     declared_type=typeof(value),
 )
+    if _no_status_conversion(model.status_conversion)
+        initial = private_copy ? _private_initial_value(value) : value
+        return initial, false, nothing
+    end
     key = _status_conversion_record_key(
         variable;
         object_id=object_id,

--- a/test/test-model-hard-calls.jl
+++ b/test/test-model-hard-calls.jl
@@ -308,7 +308,8 @@ end
     )
     continue!(simulation)
     refreshed_call_view = call_targets(CALL_RETURN_CONTEXT[], :one)
-    @test only(only(refreshed_call_view.execution_batches).targets) !==
+    # Adding an unrelated Many callee must not rebuild this unchanged One target.
+    @test only(only(refreshed_call_view.execution_batches).targets) ===
           cached_execution_target
     @test_throws ArgumentError run_call!(nothing, :one)
 
@@ -378,7 +379,7 @@ end
     @test call.callee_object_ids == [:leaf_a, :leaf_b]
     @test call.callee_application_ids == [:leaf_calls]
 
-    simulation = run!(model; outputs=:all)
+    simulation = run!(model; outputs=:all, performance=true)
     controller = only(model_objects(model; scale=:Scene)).status
     @test controller.ncalls == 2
     @test controller.total == 2.0
@@ -394,6 +395,8 @@ end
         Object(:leaf_c; scale=:Leaf, parent=:scene),
     )
     continue!(simulation; steps=1)
+    performance = Advanced.runtime_performance(simulation)
+    @test performance.counts[:execution_target_call_batches_extended] == 1
     @test controller.ncalls == 3
     @test controller.total == 5.0
 

--- a/test/test-model-output-destination-declarations.jl
+++ b/test/test-model-output-destination-declarations.jl
@@ -282,11 +282,19 @@ end
         Object(:scene; scale=:Scene);
         applications=scene.applications,
     )
-    simulation = run!(dynamic_scene; outputs=:none)
+    simulation = run!(dynamic_scene; outputs=:none, performance=true)
     initial_compiled_type = typeof(simulation.compiled)
+    initial_scenario_plan = simulation.compiled.scenario_plan
+    initial_status_view = only(values(simulation.compiled.status_views_by_target))
     register_object!(dynamic_scene, Object(:dynamic_leaf; scale=:Leaf); parent=:scene)
     continue!(simulation)
     @test typeof(simulation.compiled) === initial_compiled_type
+    @test simulation.compiled.scenario_plan === initial_scenario_plan
+    @test only(values(simulation.compiled.status_views_by_target)) ===
+          initial_status_view
+    performance = Advanced.runtime_performance(simulation)
+    @test get(performance.counts, :status_views_constructed, 0) == 0
+    @test performance.counts[:execution_targets_constructed] == 1
     @test only(model_objects(dynamic_scene; scale=:Leaf)).status.incident_par == 0.0
 end
 


### PR DESCRIPTION
## Why

XPalm creates phytomers and their organs dynamically during long simulations. After distributed output targets were introduced, every structural addition disabled the incremental scene extension path and recompiled a growing part of the complete scene.

On the 4,160-day XPalm benchmark, this changed the runtime from seconds to roughly 8-9 minutes and caused hundreds of gigabytes of cumulative allocations. Exporting leaf-scale values was not the main cause: the lifecycle compiler work dominated the profile.

## What changed

- keep incremental scene extension enabled when distributed outputs are compiled;
- extend distributed destination columns, membership indexes, and writer ownership only for newly added objects;
- fall back to the complete distributed-output compilation path for removals, reparenting, incompatible carrier types, or other non-additive changes;
- pass the refreshed distributed-output cache through input binding and status-view compilation;
- append only new hard-call execution targets when a `Many` call gains callees, while preserving the safe rebuild path when targets are removed or moved;
- skip status-conversion bookkeeping when no conversion policy is configured;
- add regression assertions for incremental distributed destinations and hard-call target reuse.

## Performance

All figures below are cumulative measurements for 4,160 simulated days.

| Configuration | Runtime | Allocations |
| --- | ---: | ---: |
| PlantSimEngine 0.14.1 reference stack | 4.73 s median | 6.99 GB |
| New API before this fix | about 510-540 s | 576.8 GB |
| New API with this fix and usual outputs | 13.24-13.35 s | 8.68 GB |
| Fixed API plus one value for every leaf and day | 17.52-19.32 s | 13.82 GB |

The leaf-scale case materializes 774,704 rows. Its additional cost is therefore proportional to the exported data volume rather than to repeated scene recompilation.

Repeated runs with the fixed current stack retained the same final state: 344 phytomers, LAI `4.1149836058460005`, and FTSW `0.7991179101191191`.

## Validation

- focused distributed-output declaration tests;
- focused distributed-output runtime tests, including addition, removal, and reparenting;
- hard-call tests, including incremental `Many` extension and safe removal fallback;
- API stabilization tests;
- status-conversion, lifecycle, and performance tests;
- repeated 4,160-day XPalm runs with usual outputs, no outputs, and a leaf-scale output.

The complete PlantSimEngine test suite was not run locally.
